### PR TITLE
Allow data before the encapsulation boundaries as per RFC-7468 Sec. 2

### DIFF
--- a/src/secret-details.tsx
+++ b/src/secret-details.tsx
@@ -38,8 +38,14 @@ export class SecretDetails extends React.Component<Renderer.Component.KubeObject
         "base64"
       ).toString("ascii");
 
-      if (!certificateString.startsWith("-----BEGIN CERTIFICATE-----"))
+      const PEM_CERTIFICATE_HEADER = "-----BEGIN CERTIFICATE-----";
+      const PEM_CERTIFICATE_FOOTER = "-----END CERTIFICATE-----";
+
+      if (!certificateString.includes(PEM_CERTIFICATE_HEADER) ||
+        !certificateString.includes(PEM_CERTIFICATE_FOOTER)) {
+        // The certificate string does not have the correct PEM format
         continue;
+      }
 
       try {
         let secureContext = tls.createSecureContext({


### PR DESCRIPTION
According to [RFC-7468 Section 2](https://www.rfc-editor.org/rfc/rfc7468#section-2) it is allowed to include data outside the boundaries of the PEM block:

> Data before the encapsulation boundaries are permitted, and parsers MUST NOT malfunction when processing such data.

As a user of OpenLens and this extension, I would like to see the certificate info even if a secret does not start with `"-----BEGIN CERTIFICATE-----"` but includes some other data before (e.g. comments including human readable information about the certificate) 