### PR TITLE
feat: Add the cert serial number to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.1.0](https://github.com/jkroepke/lens-extension-certificate-info/compare/v3.0.1...v3.1.0) (2024-05-02)
+
+### Features
+
+* Add cert serial number to output
+
+
 ## [3.0.1](https://github.com/jkroepke/lens-extension-certificate-info/compare/v3.0.0...v3.0.1) (2022-07-29)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "lens": "^5.0.0-beta.7"
+        "lens": "^6.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lens-certificate-info",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "Jan-Otto Kröpke <mail@jkroepke.de> (https://github.com/jkroepke)",
   "publisher": "jkroepke",
   "description": "Lens extension get infos from certificates inside secrets.",

--- a/src/secret-details.tsx
+++ b/src/secret-details.tsx
@@ -71,7 +71,7 @@ export class SecretDetails extends React.Component<Renderer.Component.KubeObject
               <Renderer.Component.DrawerItem name="SAN">
                 {this.formatSAN(cert.subjectaltname)}
               </Renderer.Component.DrawerItem>
-              <Renderer.Component.DrawerItem name="Serial Numbers">
+              <Renderer.Component.DrawerItem name="Serial Number">
                 {cert.serialNumber}
               </Renderer.Component.DrawerItem>
               <Renderer.Component.DrawerItem name="Issuer">

--- a/src/secret-details.tsx
+++ b/src/secret-details.tsx
@@ -71,6 +71,9 @@ export class SecretDetails extends React.Component<Renderer.Component.KubeObject
               <Renderer.Component.DrawerItem name="SAN">
                 {this.formatSAN(cert.subjectaltname)}
               </Renderer.Component.DrawerItem>
+              <Renderer.Component.DrawerItem name="Serial Numbers">
+                {cert.serialNumber}
+              </Renderer.Component.DrawerItem>
               <Renderer.Component.DrawerItem name="Issuer">
                 {cert.issuer.CN}
               </Renderer.Component.DrawerItem>


### PR DESCRIPTION
Had a request from someone on team to be able to see cert Serial Number in the output. Wondering if this would be beneficial to more people than just us.